### PR TITLE
Lower limit_req_zone rate to 2r/s (120r/m)

### DIFF
--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -27,7 +27,7 @@ http {
         keepalive 16;
     }
 
-    limit_req_zone  $binary_remote_addr  zone=one:10m   rate=300r/m;
+    limit_req_zone  $binary_remote_addr  zone=one:10m   rate=2r/s;
     limit_req_status 429;
     
     server {


### PR DESCRIPTION
Lower limit_req_zone rate to 2r/s (120r/m)

related https://github.com/vaidas-lungis/heroku-buildpack-php/pull/3