### PR TITLE
Increase zone size from 10m to 100m

### DIFF
--- a/conf/nginx/heroku.conf.php
+++ b/conf/nginx/heroku.conf.php
@@ -27,7 +27,7 @@ http {
         keepalive 16;
     }
 
-    limit_req_zone  $binary_remote_addr  zone=one:10m   rate=300r/m;
+    limit_req_zone  $binary_remote_addr  zone=one:100m   rate=300r/m;
     limit_req_status 429;
     
     server {


### PR DESCRIPTION
Increase zone size from 10m to 100m

> One megabyte zone can keep about 16 thousand 64-byte states or about 8 thousand 128-byte states. If the zone storage is exhausted, the server will return the 503 (Service Temporarily Unavailable) error to all further requests.

http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_zone